### PR TITLE
feature: using wasm instead of rustyscript

### DIFF
--- a/eucalyptus-core/src/scripting/mod.rs
+++ b/eucalyptus-core/src/scripting/mod.rs
@@ -26,6 +26,7 @@ pub trait ScriptableModule {
     // fn release(world: &mut World, entity_id: hecs::Entity, data: &serde_json::Value) -> anyhow::Result<()>;
 }
 
+
 pub const TEMPLATE_SCRIPT: &'static str = include_str!("../../../resources/template.ts");
 
 pub enum ScriptAction {


### PR DESCRIPTION
so, i have come across an issue where using the rustyscript library caused a pain in the ass with tokio runtimes, so I have decided to switch to WASM. also there is no android/mobile support so this is easier. also more versatile. I think i'm just trying to cope :(